### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+
+env:
+  - DJANGO="Django>=1.6,<1.7"
+  - DJANGO="Django>=1.5,<1.6"
+  - DJANGO="Django>=1.4,<1.5"
+  - DJANGO="Django>=1.3,<1.4"
+
+install:
+  - pip install $DJANGO django-jsonfield
+
+script: 'tests/runtests.py'
+
+matrix:
+  exclude:
+    - python: "3.3"
+      env: DJANGO="Django>=1.4,<1.5"
+    - python: "3.3"
+      env: DJANGO="Django>=1.3,<1.4"

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. image::
+   https://travis-ci.org/dym/django-offline-messages.png
+   :target: https://travis-ci.org/dym/django-offline-messages
+
 =========================
 Installation Instructions
 =========================


### PR DESCRIPTION
Could you please setup travis ci for this repo on https://travis-ci.org/profile ?

With .travis.yml attached to this pull request, it should work straight away, though it's likely for Django 1.3 and 1.6 to trigger build errors

Cheers!
