### PR TITLE
Fix django.contrib.contenttypes.generic import shim removed in Django 1.9

### DIFF
--- a/offline_messages/models.py
+++ b/offline_messages/models.py
@@ -10,7 +10,10 @@ from django.contrib.messages import constants
 from django.contrib.messages.utils import get_level_tags
 
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except ImportError:
+    from django.contrib.contenttypes.generic import GenericForeignKey
 
 from jsonfield import JSONField
 
@@ -59,7 +62,7 @@ class OfflineMessage(models.Model):
 
     content_type = models.ForeignKey(ContentType, blank=True, null=True)
     object_id = models.PositiveIntegerField(blank=True, null=True)
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id')
 
     meta = JSONField(default={}, blank=True, null=True)
 


### PR DESCRIPTION
Django 1.9 removes the deprecated import shim that was in `django.contrib.contenttypes.generic` for Django 1.7 and 1.8 (i.e. generic.py no longer exists). This PR changes the import path for `GenericForeignKey` to `django.contrib.contenttypes.fields` for Django >= 1.7, and remains compatible with Django < 1.7.

(Django 1.9 is due to be released on 1 December.)